### PR TITLE
Drop Python 2.7 support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ usual:
 
     $ pip install plottie
 
+> NB: Plottie requires Python 3.5+
+
 In most cases, all you need to do is run `plottie` with your SVG file as
 the argument:
 

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,6 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Operating System :: MacOS",
 
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.5",
     ],


### PR DESCRIPTION
Python 2.7 is deprecated and clearly I have not been testing support for it properly. As such I'm making this lack of support explicit in the docs/metadata.

(Addresses #1)