### PR TITLE
Add auto-blade support.

### DIFF
--- a/plottie/cli.py
+++ b/plottie/cli.py
@@ -283,6 +283,15 @@ def make_argument_parser():
         """,
     )
     
+    plotting_parameters.add_argument(
+        "--auto-blade-depth", "-b",
+        type=int,
+        help="""
+            Set the auto-blade depth setting to use for devices which support
+            it. If this argument is not given, the blade is not adjusted.
+        """,
+    )
+    
     # #########################################################################
     
     ordering_parameters = parser.add_argument_group("plotting and cutting order arguments")
@@ -760,6 +769,11 @@ def main(args=None):
     
     args.device.set_force(args.force)
     args.device.set_speed(args.speed)
+    if args.auto_blade_depth is not None:
+        try:
+            args.device.set_depth(args.auto_blade_depth)
+        except py_silhouette.AutoBladeNotSupportedError:
+            sys.stderr.write("--auto-blade-depth not supported by this device")
     args.device.set_tool_diameter(
         args.device.params.tool_diameters["Knife"]
         if args.plot_mode == PlotMode.cut else

--- a/plottie/dummy_device.py
+++ b/plottie/dummy_device.py
@@ -26,6 +26,7 @@ class DummyDevice(object):
         self.regmarks_used = False
         self.speed = None
         self.force = None
+        self.depth = None
         self.tool_diameter = None
         self.paths = [[(0, 0)]]  # [[(x, y), ...], ...]
     
@@ -49,6 +50,9 @@ class DummyDevice(object):
     
     def set_force(self, force):
         self.force = force
+    
+    def set_depth(self, depth):
+        self.depth = depth
     
     def set_tool_diameter(self, tool_diameter):
         self.tool_diameter = tool_diameter

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,13 @@ setup(
     ],
     keywords="svg plotter cutter silhouette",
 
-    install_requires=["svgoutline", "py_silhouette", "attrs", "toposort", "enum34"],
+    install_requires=[
+        "svgoutline",
+        "py_silhouette>=0.2.0",
+        "attrs",
+        "toposort",
+        "enum34",
+    ],
     
     entry_points={
         "console_scripts": [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -371,7 +371,7 @@ class TestAbsoluteOrPercentageWithin(object):
             absolute_or_percentage_within(string, 10000, 11000)
 
 
-class TestSpeedAndForce(object):
+class TestSpeedForceAndDepth(object):
     
     def test_valid_speed(self):
         parser = make_argument_parser()


### PR DESCRIPTION
Fixes #3 

Thanks for your patience and help, @derwassi! If I could ask you for one final favour, would you be happy to verify that the auto-blade support added in this branch works?

Install with:

```
$ git clone git@github.com:mossblaser/plottie.git
$ cd plottie
$ git checkout add-auto-blade-support
$ virtualenv -p python3 venv
$ . venv/bin/activate
$ pip install -e .
```

Then plot something, adding a `--auto-blade-depth` or `-b` argument:

```
$ plottie -b 3 /path/to/some.svg
```

Thanks again for your help!